### PR TITLE
Parser Rewrite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target/
 dicebot-config
 todo
+todo.org
 cache
 *.tar
 *.tar.gz

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "actix",
  "actix-rt",
  "async-trait",
+ "combine",
  "dirs",
  "env_logger",
  "indoc",
@@ -287,6 +288,7 @@ dependencies = [
  "matrix-sdk-common 0.1.0 (git+https://github.com/matrix-org/matrix-rust-sdk?rev=0.1.0)",
  "matrix-sdk-common-macros",
  "nom",
+ "once_cell",
  "rand",
  "serde",
  "thiserror",
@@ -323,6 +325,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2809f67365382d65fd2b6d9c22577231b954ed27400efeafbe687bda75abcc0b"
+dependencies = [
+ "bytes",
+ "memchr",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ dirs = "3.0"
 indoc = "1.0"
 actix = "0.10"
 actix-rt = "1.1"
+combine = "4.3"
+once_cell = "1.4"
 
 # The versioning of the matrix SDK follows its Cargo.toml. The SDK and
 # macros are on master, but it imports the common and base from 0.1.0.

--- a/src/cofd/parser.rs
+++ b/src/cofd/parser.rs
@@ -1,124 +1,205 @@
-use nom::{
-    alt, bytes::complete::tag, character::complete::digit1, complete, many0, named,
-    sequence::tuple, tag, IResult,
-};
+use crate::cofd::dice::{Amount, DicePool, DicePoolModifiers, DicePoolQuality, Element, Operator};
+use crate::error::BotError;
+use combine::error::StringStreamError;
+use combine::parser::char::{digit, letter, spaces, string};
+use combine::{choice, count, many, many1, one_of, Parser};
 
-use crate::cofd::dice::{DicePool, DicePoolQuality};
-use crate::parser::eat_whitespace;
-
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum DicePoolElement {
-    NumberOfDice(u32),
-    SuccessesForExceptional(u32),
-    DicePoolQuality(DicePoolQuality),
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ParsedInfo {
+    Quality(DicePoolQuality),
+    ExceptionalOn(i32),
 }
 
-// Parse a single digit expression.  Does not eat whitespace
-fn parse_digit(input: &str) -> IResult<&str, u32> {
-    let (input, num) = digit1(input)?;
-    Ok((input, num.parse().unwrap()))
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum DiceParsingError {
+    InvalidAmount,
+    InvalidModifiers,
+    UnconsumedInput,
 }
 
-fn parse_quality(input: &str) -> IResult<&str, DicePoolQuality> {
-    let (input, _) = eat_whitespace(input)?;
-    named!(quality(&str) -> DicePoolQuality, alt!(
-        complete!(tag!("n")) => { |_| DicePoolQuality::NineAgain } |
-        complete!(tag!("e")) => { |_| DicePoolQuality::EightAgain } |
-        complete!(tag!("r")) => { |_| DicePoolQuality::Rote } |
-        complete!(tag!("x")) => { |_| DicePoolQuality::NoExplode }
-    ));
-
-    let (input, dice_pool_quality) = quality(input)?;
-    Ok((input, dice_pool_quality))
+impl std::fmt::Display for DiceParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
 }
 
-fn parse_exceptional_requirement(input: &str) -> IResult<&str, u32> {
-    let (input, _) = eat_whitespace(input)?;
-    let (input, (_, successes)) = tuple((tag("s"), digit1))(input)?;
-    Ok((input, successes.parse().unwrap()))
+impl std::error::Error for DiceParsingError {
+    fn description(&self) -> &str {
+        self.as_str()
+    }
 }
 
-// Parse a dice pool element expression.  Eats whitespace.
-fn parse_dice_pool_element(input: &str) -> IResult<&str, DicePoolElement> {
-    let (input, _) = eat_whitespace(input)?;
-    named!(element(&str) -> DicePoolElement, alt!(
-        parse_digit => { |num| DicePoolElement::NumberOfDice(num) } |
-        parse_quality => { |qual| DicePoolElement::DicePoolQuality(qual) } |
-        parse_exceptional_requirement => { |succ| DicePoolElement::SuccessesForExceptional(succ) }
-    ));
-
-    let (input, element) = element(input)?;
-    Ok((input, element))
-}
-
-fn find_elements(elements: Vec<DicePoolElement>) -> (Option<u32>, DicePoolQuality, u32) {
-    let mut found_quality: Option<DicePoolQuality> = None;
-    let mut found_count: Option<u32> = None;
-    let mut found_successes_required: Option<u32> = None;
-
-    for element in elements {
-        if found_quality.is_some() && found_count.is_some() && found_successes_required.is_some() {
-            break;
+impl DiceParsingError {
+    fn as_str(&self) -> &str {
+        use self::DiceParsingError::*;
+        match *self {
+            InvalidAmount => "invalid amount of dice",
+            InvalidModifiers => "dice pool modifiers not specified properly",
+            UnconsumedInput => "extraneous input detected",
         }
-
-        match element {
-            DicePoolElement::NumberOfDice(found) => {
-                if found_count.is_none() {
-                    found_count = Some(found);
-                }
-            }
-            DicePoolElement::DicePoolQuality(found) => {
-                if found_quality.is_none() {
-                    found_quality = Some(found);
-                }
-            }
-            DicePoolElement::SuccessesForExceptional(found) => {
-                if found_successes_required.is_none() {
-                    found_successes_required = Some(found);
-                }
-            }
-        };
     }
-
-    let quality: DicePoolQuality = found_quality.unwrap_or(DicePoolQuality::TenAgain);
-    let successes_for_exceptional: u32 = found_successes_required.unwrap_or(5);
-    (found_count, quality, successes_for_exceptional)
 }
 
-fn convert_to_dice_pool(input: &str, elements: Vec<DicePoolElement>) -> IResult<&str, DicePool> {
-    let (count, quality, successes_for_exceptional) = find_elements(elements);
+pub fn parse_modifiers(input: &str) -> Result<DicePoolModifiers, BotError> {
+    if input.len() == 0 {
+        return Ok(DicePoolModifiers::default());
+    }
 
-    if count.is_some() {
-        Ok((
-            input,
-            DicePool::new(count.unwrap(), successes_for_exceptional, quality),
+    let input = input.trim();
+
+    let quality = one_of("nerx".chars())
+        .skip(spaces().silent())
+        .map(|quality| match quality {
+            'n' => ParsedInfo::Quality(DicePoolQuality::NineAgain),
+            'e' => ParsedInfo::Quality(DicePoolQuality::EightAgain),
+            'r' => ParsedInfo::Quality(DicePoolQuality::Rote),
+            'x' => ParsedInfo::Quality(DicePoolQuality::NoExplode),
+            _ => ParsedInfo::Quality(DicePoolQuality::TenAgain), //TODO add warning log
+        });
+
+    let exceptional_on = string("s")
+        .and(many1(digit()))
+        .map(|s| s.1) //Discard the s; only need the number
+        .skip(spaces().silent())
+        .map(|num_as_str: String| {
+            ParsedInfo::ExceptionalOn(match num_as_str.parse::<i32>() {
+                Ok(success_on) => success_on,
+                Err(_) => 5, //TODO add warning log
+            })
+        });
+
+    let mut parser = count(2, choice((quality, exceptional_on)))
+        .skip(spaces().silent())
+        .map(|modifiers: Vec<ParsedInfo>| modifiers);
+
+    let (result, rest) = parser.parse(input)?;
+
+    if rest.len() == 0 {
+        convert_to_info(&result)
+    } else {
+        Err(BotError::DiceParsingError(
+            DiceParsingError::UnconsumedInput,
         ))
-    } else {
-        use nom::error::ErrorKind;
-        use nom::Err;
-        Err(Err::Error((input, ErrorKind::Alt)))
     }
 }
 
-pub fn parse_dice_pool(input: &str) -> IResult<&str, DicePool> {
-    named!(first_element(&str) -> DicePoolElement, alt!(
-            parse_dice_pool_element => { |e| e }
-    ));
-    let (input, first) = first_element(input)?;
-    let (input, elements) = if input.trim().is_empty() {
-        (input, vec![first])
+fn convert_to_info(parsed: &Vec<ParsedInfo>) -> Result<DicePoolModifiers, BotError> {
+    use ParsedInfo::*;
+    if parsed.len() == 0 {
+        Ok(DicePoolModifiers::default())
+    } else if parsed.len() == 1 {
+        match parsed[0] {
+            ExceptionalOn(exceptional_on) => {
+                Ok(DicePoolModifiers::custom_exceptional_on(exceptional_on))
+            }
+            Quality(quality) => Ok(DicePoolModifiers::custom_quality(quality)),
+        }
+    } else if parsed.len() == 2 {
+        match parsed[..] {
+            [ExceptionalOn(exceptional_on), Quality(quality)] => {
+                Ok(DicePoolModifiers::custom(quality, exceptional_on))
+            }
+            [Quality(quality), ExceptionalOn(exceptional_on)] => {
+                Ok(DicePoolModifiers::custom(quality, exceptional_on))
+            }
+            _ => Err(DiceParsingError::InvalidModifiers.into()),
+        }
     } else {
-        named!(rest_elements(&str) -> Vec<DicePoolElement>, many0!(parse_dice_pool_element));
-        let (input, mut rest) = rest_elements(input)?;
-        rest.insert(0, first);
-        (input, rest)
-    };
-
-    convert_to_dice_pool(input, elements)
+        //We don't expect this clause to be hit, because the parser works 0 to 2 times.
+        Err(DiceParsingError::InvalidModifiers.into())
+    }
 }
 
-pub fn create_chance_die() -> IResult<&'static str, DicePool> {
-    Ok(("", DicePool::chance_die()))
+/// Parse dice pool amounts into elements coupled with operators,
+/// where an operator is "+" or "-", and an element is either a number
+/// or variable name. The first element should not have an operator,
+/// but every one after that should. Accepts expressions like "8", "10
+/// + variablename", "variablename - 3", etc.
+fn parse_pool_amount(input: &str) -> Result<Vec<Amount>, BotError> {
+    let input = input.trim();
+
+    let plus_or_minus = one_of("+-".chars());
+    let maybe_sign = plus_or_minus.map(|sign: char| match sign {
+        '+' => Operator::Plus,
+        '-' => Operator::Minus,
+        _ => Operator::Plus,
+    });
+
+    //TODO make this a macro or something
+    let first = many1(letter())
+        .or(many1(digit()))
+        .skip(spaces().silent()) //Consume any space after first amount
+        .map(|value: String| match value.parse::<i32>() {
+            Ok(num) => Amount {
+                operator: Operator::Plus,
+                element: Element::Number(num),
+            },
+            _ => Amount {
+                operator: Operator::Plus,
+                element: Element::Variable(value),
+            },
+        });
+
+    let variable_or_number =
+        many1(letter())
+            .or(many1(digit()))
+            .map(|value: String| match value.parse::<i32>() {
+                Ok(num) => Element::Number(num),
+                _ => Element::Variable(value),
+            });
+
+    let sign_and_word = maybe_sign
+        .skip(spaces().silent())
+        .and(variable_or_number)
+        .skip(spaces().silent())
+        .map(|parsed: (Operator, Element)| Amount {
+            operator: parsed.0,
+            element: parsed.1,
+        });
+
+    let rest = many(sign_and_word).map(|expr: Vec<_>| expr);
+
+    let mut parser = first.and(rest);
+
+    //Maps the found expression into a Vec of Amount instances,
+    //tacking the first one on.
+    type ParsedAmountExpr = (Amount, Vec<Amount>);
+    let (results, rest) = parser
+        .parse(input)
+        .map(|mut results: (ParsedAmountExpr, &str)| {
+            let mut amounts = vec![(results.0).0];
+            amounts.append(&mut (results.0).1);
+            (amounts, results.1)
+        })?;
+
+    if rest.len() == 0 {
+        Ok(results)
+    } else {
+        Err(BotError::DiceParsingError(
+            DiceParsingError::UnconsumedInput,
+        ))
+    }
+}
+
+pub fn parse_dice_pool(input: &str) -> Result<DicePool, BotError> {
+    //The "modifiers:" part is optional. Assume amounts if no modifier
+    //section found.
+    let split = input.split(":").collect::<Vec<_>>();
+    let (modifiers_str, amounts_str) = (match split[..] {
+        [amounts] => Ok(("", amounts)),
+        [modifiers, amounts] => Ok((modifiers, amounts)),
+        _ => Err(BotError::DiceParsingError(
+            DiceParsingError::UnconsumedInput,
+        )),
+    })?;
+
+    let modifiers = parse_modifiers(modifiers_str)?;
+    let amounts = parse_pool_amount(&amounts_str)?;
+    Ok(DicePool::new(amounts, modifiers))
+}
+
+pub fn create_chance_die() -> Result<DicePool, StringStreamError> {
+    Ok(DicePool::chance_die())
 }
 
 #[cfg(test)]
@@ -126,109 +207,206 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_digit_test() {
-        use nom::error::ErrorKind;
-        use nom::Err;
-        assert_eq!(parse_digit("1"), Ok(("", 1)));
-        assert_eq!(parse_digit("10"), Ok(("", 10)));
+    fn parse_single_number_amount_test() {
+        let result = parse_pool_amount("1");
+        assert!(result.is_ok());
         assert_eq!(
-            parse_digit("adsf"),
-            Err(Err::Error(("adsf", ErrorKind::Digit)))
+            result.unwrap(),
+            vec![Amount {
+                operator: Operator::Plus,
+                element: Element::Number(1)
+            }]
         );
+
+        let result = parse_pool_amount("10");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            vec![Amount {
+                operator: Operator::Plus,
+                element: Element::Number(10)
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_single_variable_amount_test() {
+        let result = parse_pool_amount("asdf");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            vec![Amount {
+                operator: Operator::Plus,
+                element: Element::Variable("asdf".to_string())
+            }]
+        );
+
+        let result = parse_pool_amount("nosis");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            vec![Amount {
+                operator: Operator::Plus,
+                element: Element::Variable("nosis".to_string())
+            }]
+        );
+    }
+
+    #[test]
+    fn parse_complex_amount_expression() {
+        assert!(parse_pool_amount("1 + myvariable - 2").is_ok());
     }
 
     #[test]
     fn quality_test() {
-        use nom::error::ErrorKind;
-        use nom::Err;
-        assert_eq!(parse_quality("n"), Ok(("", DicePoolQuality::NineAgain)));
-        assert_eq!(parse_quality("e"), Ok(("", DicePoolQuality::EightAgain)));
-        assert_eq!(parse_quality("r"), Ok(("", DicePoolQuality::Rote)));
-        assert_eq!(parse_quality("x"), Ok(("", DicePoolQuality::NoExplode)));
-        assert_eq!(parse_quality("b"), Err(Err::Error(("b", ErrorKind::Alt))));
+        let result = parse_modifiers("n");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            DicePoolModifiers::custom_quality(DicePoolQuality::NineAgain)
+        );
+
+        let result = parse_modifiers("e");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            DicePoolModifiers::custom_quality(DicePoolQuality::EightAgain)
+        );
+
+        let result = parse_modifiers("r");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            DicePoolModifiers::custom_quality(DicePoolQuality::Rote)
+        );
+
+        let result = parse_modifiers("x");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            DicePoolModifiers::custom_quality(DicePoolQuality::NoExplode)
+        );
+
+        let result = parse_modifiers("b");
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(BotError::DiceParsingError(
+                DiceParsingError::UnconsumedInput
+            ))
+        ));
     }
 
     #[test]
-    fn multiple_quality_test() {
-        assert_eq!(parse_quality("ner"), Ok(("er", DicePoolQuality::NineAgain)));
+    fn multiple_quality_failure_test() {
+        let result = parse_modifiers("ne");
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(BotError::DiceParsingError(
+                DiceParsingError::InvalidModifiers
+            ))
+        ));
     }
 
     #[test]
     fn exceptional_success_test() {
-        use nom::error::ErrorKind;
-        use nom::Err;
-        assert_eq!(parse_exceptional_requirement("s3"), Ok(("", 3)));
-        assert_eq!(parse_exceptional_requirement("s10"), Ok(("", 10)));
-        assert_eq!(parse_exceptional_requirement("s20b"), Ok(("b", 20)));
-        assert_eq!(
-            parse_exceptional_requirement("sab10"),
-            Err(Err::Error(("ab10", ErrorKind::Digit)))
-        );
-    }
+        let result = parse_modifiers("s3");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), DicePoolModifiers::custom_exceptional_on(3));
 
-    #[test]
-    fn dice_pool_element_expression_test() {
-        use nom::error::ErrorKind;
-        use nom::Err;
-
+        let result = parse_modifiers("s33");
+        assert!(result.is_ok());
         assert_eq!(
-            parse_dice_pool_element("8"),
-            Ok(("", DicePoolElement::NumberOfDice(8)))
+            result.unwrap(),
+            DicePoolModifiers::custom_exceptional_on(33)
         );
 
-        assert_eq!(
-            parse_dice_pool_element("n"),
-            Ok((
-                "",
-                DicePoolElement::DicePoolQuality(DicePoolQuality::NineAgain)
+        let result = parse_modifiers("s3q");
+        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(BotError::DiceParsingError(
+                DiceParsingError::UnconsumedInput
             ))
-        );
-
-        assert_eq!(
-            parse_dice_pool_element("s3"),
-            Ok(("", DicePoolElement::SuccessesForExceptional(3)))
-        );
-
-        assert_eq!(
-            parse_dice_pool_element("8ns3"),
-            Ok(("ns3", DicePoolElement::NumberOfDice(8)))
-        );
-
-        assert_eq!(
-            parse_dice_pool_element("totallynotvalid"),
-            Err(Err::Error(("totallynotvalid", ErrorKind::Alt)))
-        );
+        ));
     }
 
     #[test]
     fn dice_pool_number_only_test() {
+        let result = parse_dice_pool("8");
+        assert!(result.is_ok());
         assert_eq!(
-            parse_dice_pool("8"),
-            Ok(("", DicePool::new(8, 5, DicePoolQuality::TenAgain)))
+            result.unwrap(),
+            DicePool::easy_pool(8, DicePoolQuality::TenAgain)
         );
     }
 
     #[test]
     fn dice_pool_number_with_quality() {
+        let result = parse_dice_pool("n:8");
+        assert!(result.is_ok());
         assert_eq!(
-            parse_dice_pool("8n"),
-            Ok(("", DicePool::new(8, 5, DicePoolQuality::NineAgain)))
+            result.unwrap(),
+            DicePool::easy_pool(8, DicePoolQuality::NineAgain)
         );
     }
 
     #[test]
     fn dice_pool_number_with_success_change() {
-        assert_eq!(
-            parse_dice_pool("8s3"),
-            Ok(("", DicePool::new(8, 3, DicePoolQuality::TenAgain)))
-        );
+        let modifiers = DicePoolModifiers::custom_exceptional_on(3);
+        let result = parse_dice_pool("s3:8");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), DicePool::easy_with_modifiers(8, modifiers));
     }
 
     #[test]
     fn dice_pool_with_quality_and_success_change() {
-        assert_eq!(
-            parse_dice_pool("8rs3"),
-            Ok(("", DicePool::new(8, 3, DicePoolQuality::Rote)))
-        );
+        let modifiers = DicePoolModifiers::custom(DicePoolQuality::Rote, 3);
+        let result = parse_dice_pool("rs3:8");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), DicePool::easy_with_modifiers(8, modifiers));
+    }
+
+    #[test]
+    fn dice_pool_complex_expression_test() {
+        let modifiers = DicePoolModifiers::custom(DicePoolQuality::Rote, 3);
+        let amounts = vec![
+            Amount {
+                operator: Operator::Plus,
+                element: Element::Number(8),
+            },
+            Amount {
+                operator: Operator::Plus,
+                element: Element::Number(10),
+            },
+            Amount {
+                operator: Operator::Minus,
+                element: Element::Number(2),
+            },
+            Amount {
+                operator: Operator::Plus,
+                element: Element::Variable("varname".to_owned()),
+            },
+        ];
+
+        let expected = DicePool::new(amounts, modifiers);
+
+        let result = parse_dice_pool("rs3:8+10-2+varname");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected);
+
+        let result = parse_dice_pool("rs3:8+10-   2 + varname");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected);
+
+        let result = parse_dice_pool("rs3  :  8+ 10 -2 + varname");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected);
+
+        //This one has tabs in it.
+        let result = parse_dice_pool("  r	s3  :	8	+ 10 -2 + varname");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), expected);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,4 +33,19 @@ pub enum BotError {
 
     #[error("i/o error")]
     IoError(#[from] std::io::Error),
+
+    #[error("parsing error")]
+    ParserError(#[from] combine::error::StringStreamError),
+
+    #[error("dice parsing error")]
+    DiceParsingError(#[from] crate::cofd::parser::DiceParsingError),
+
+    #[error("legacy parsing error")]
+    NomParserError(nom::error::ErrorKind),
+
+    #[error("legacy parsing error: not enough data")]
+    NomParserIncomplete,
+
+    #[error("variables not yet supported")]
+    VariablesNotSupported,
 }


### PR DESCRIPTION
Rewrite of the CofD dice pool parser and core command parsing to use `combine` instead of `nom`. The dice pool parser has been rewritten in preparation for use of variables and more complicated expressions to allow bonuses/penalties. The command parser was rewritten to use `combine` simply because I find it less confusing than `nom`. The only thing that uses `nom` is the original dice rolling code. The legacy code boundary is contained in the `parse_roll` function in `src/commands/parser.rs`.